### PR TITLE
fix: increase login timeout from 10s to 30s

### DIFF
--- a/HOTFIX_LOG.md
+++ b/HOTFIX_LOG.md
@@ -1,0 +1,1 @@
+# Hotfix Log\n\n## 2026-03-22 — Login Timeout Fix\n- Increased login page timeout from 10s to 30s\n- Resolves issue #2


### PR DESCRIPTION
## Hotfix

Fixes #2 — Login page timeout on slow network.

### Changes
- Increased default login timeout from 10s to 30s

### Root Cause
Hardcoded 10s timeout was insufficient for slow network conditions.

> Workflow test PR — safe to close.